### PR TITLE
Fix for installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a set of extensions to make working with Fat-Free a little richer.
 
 Installation
 -------
-Run `composer require n0nag0n/fatfree-tracy-devtools --dev` and you're on your way!
+Run `composer require n0nag0n/fatfree-tracy-extensions --dev` and you're on your way!
 
 Configuration
 -------

--- a/src/Extension/Request_Extension.php
+++ b/src/Extension/Request_Extension.php
@@ -27,6 +27,8 @@ class Request_Extension extends Extension_Base implements \Tracy\IBarPanel {
 		$files_html = $this->handleLongStrings($_FILES);
 		$request_data['REQUEST_URI'] = $this->handleLongStrings($request_data['REQUEST_URI']);
 		$request_data['HTTP_USER_AGENT'] = $this->handleLongStrings($request_data['HTTP_USER_AGENT']);
+
+		$request_data['USER'] = !empty($request_data['USER']) ? $request_data['USER'] : '';
 		$view_files = $this->handleLongStrings(array_filter(get_included_files(), function($value) use ($f3) { return strpos($value, $f3->UI) !== false; }));
 		$html = <<<EOT
 			<h1>Request</h1> 


### PR DESCRIPTION
This fixes the readme instructions so the composer instruction is the correct one.

Also fixes an issue in the request extension where $request_data['USER'] doesn't exist and causes an error.