### PR TITLE
Add current route handler to F3 panel

### DIFF
--- a/src/Extension/F3_Panel_Extension.php
+++ b/src/Extension/F3_Panel_Extension.php
@@ -24,6 +24,7 @@ class F3_Panel_Extension extends Extension_Base implements \Tracy\IBarPanel {
 	 */
 	public function getPanel() {
 		$f3_data = (array) $this->f3->hive();
+		$f3_data['CURRENT_ROUTE_HANDLER'] = $f3_data['ROUTES'][$this->f3->get('PATTERN')][0][$f3_data['VERB']][0];
 		ksort($f3_data, SORT_NATURAL);
 		$table_tr_html = '';
 		foreach($f3_data as $key => $value) {


### PR DESCRIPTION
This is just an addition I made locally in a project that I have found quite  useful, and wondered if it was something worth adding in.

Adds a new line to F3 panel for the current route handler path. Eg. `app\Controller\Index_Controller->indexAction`

<img width="466" alt="Screen Shot 2023-04-20 at 7 39 03 AM" src="https://user-images.githubusercontent.com/49914839/233370758-3451cbb3-4eee-4fe3-bb7c-75d027a47cd3.png">
